### PR TITLE
fixing some unchecked additions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,14 +270,15 @@ impl SerMsg {
             }
             while self.rcvd_data[self.cobs_byte as usize] > 0 {
                 let delta: u8 = self.rcvd_data[self.cobs_byte as usize];
-                if (delta + self.cobs_byte) > self.payload_len {
+
+                // check if delta make us point outside payload region
+                // saturating_add max out at 255. And it works, because:
+                // self.payload_len<=SerMsg::MAX_PACKET_SIZE<255
+                if (delta.saturating_add(self.cobs_byte)) >= self.payload_len {
                     return false;
                 }
                 self.rcvd_data[self.cobs_byte as usize] = SerMsg::START_BYTE;
                 self.cobs_byte += delta;
-                if self.cobs_byte >= self.payload_len {
-                    return false;
-                }
             }
             self.rcvd_data[self.cobs_byte as usize] = SerMsg::START_BYTE;
             true

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -354,6 +354,14 @@ mod error_tests {
             }
         }
     }
+    #[test]
+    fn test_cobs_overflow() {
+        let v = [
+            126, 1, 7, 10, 62, 144, 168, 18, 47, 0, 35, 253, 239, 188, 13, 129,
+        ];
+        let mut m = SerMsg::new();
+        m.parse_read_bytes(&v);
+    }
 
     #[test]
     fn exceeded_max_length() {


### PR DESCRIPTION
# Pull Request

## Summary
I was fuzz-testing a library that depends on this repo, and I got some errors.
Simply in SerMsg::unpack_corbs(...) there were two additions that in some particular circumstances could overflow, but rust adds some controls for this types of error and sometimes it panicked with "attempting to add with overflow".
Changing this to additions with "wrapping_add" we get a "controlled overflow" like in C (and i think this was the intent).

## Description
Changed two additions (line 273 and 277) with wrapping add.

## Motivation and Context
Fixes some hard to catch panics in an embedded context.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code has been formatted with "cargo fmt".
- [x] My code has been checked with "cargo clippy".
- [x] My code is passing all previous and new tests.
- [ ] I have added new tests for my changes (if applicable).
- [ ] My change requires a change/update to the documentation.
- [ ] I have updated the documentation accordingly.

## Other info
<!--- Put whatever you want in here -->
